### PR TITLE
Fix deprecation warnings for CHEF-19

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -4,6 +4,7 @@ driver:
 provisioner:
   name: chef_zero
   deprecations_as_errors: true
+  log_level: :warn
 
 verifier:
   name: inspec

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -26,7 +26,7 @@ end
 
 action :create do
   if current_resource
-    zfs_set_properties(name, new_resource.properties) unless new_resource.properties.nil?
+    zfs_set_properties(new_resource.name, new_resource.properties) unless new_resource.properties.nil?
   else
     cmd = %w(zfs create)
     new_resource.properties.each do |setting|
@@ -46,14 +46,14 @@ end
 action :destroy do
   execute 'zfs_destroy' do
     environment 'PATH' => "/usr/sbin:#{ENV['PATH']}" if platform_family?('solaris2')
-    command "zfs destroy #{name}"
+    command "zfs destroy #{new_resource.name}"
   end
 end
 
 action :upgrade do
   execute 'zfs_upgrade' do
     environment 'PATH' => "/usr/sbin:#{ENV['PATH']}" if platform_family?('solaris2')
-    command "zfs upgrade #{name}"
+    command "zfs upgrade #{new_resource.name}"
   end
 end
 


### PR DESCRIPTION
Chef was complaining about using `name` property directly:
```
[2018-03-02T10:05:38+00:00] ERROR: zfs[testpool/setprop] (test::default line 66) had an error: Chef::Exceptions::DeprecatedFeatureError: "rename name to new_resource.name (CHEF-19)/tmp/kitchen/cache/cookbooks/chef_zfs/resources/default.rb:29:in `block in class_from_file'.\nPlease see https://docs.chef.io/deprecations_namespace_collisions.html for further details and information on how to correct this problem. at /opt/chef/embedded/lib/ruby/gems/2.4.0/gems/chef-13.8.0/lib/chef/formatters/doc.rb:419:in `deprecation'"
```

This PR should fix it. Plus I've added warn log_level to kitchen to help catch deprecations.