### PR TITLE
Check if a given ZFS attribute is already set on the filesystem

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license          'Apache-2.0'
 description      'Manage ZFS'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.0.1'
+version          '1.0.14'
 source_url       'https://github.com/chef-cookbooks/chef_zfs'
 issues_url       'https://github.com/chef-cookbooks/chef_zfs/issues'
 


### PR DESCRIPTION
Check if a given ZFS attribute is already set on the filesystem before calling 'zfs set ...'. This is necessary because zfs set will attempt to set, for example, mountpoint even if the filesystem is already mounted at the correct location.