### PR TITLE
Add provides for Chef 15+ compatibility

### DIFF
--- a/resources/default.rb
+++ b/resources/default.rb
@@ -16,6 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+provides :zfs
 resource_name :zfs
 property :properties, Array
 


### PR DESCRIPTION
### Description

This cookbook wasn't working in Chef 15+ because it was missing a `provides :zfs`.

### Issues Resolved

This cookbook works in Chef 15, 16, 17, and 18 now.

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD> (this is a trivial/obvious change, so is theoretically not required)